### PR TITLE
[BUGFIX] Quote the property names correctly in SqLiteQueryBuilder

### DIFF
--- a/Classes/Flowpack/SimpleSearch/Search/SqLiteQueryBuilder.php
+++ b/Classes/Flowpack/SimpleSearch/Search/SqLiteQueryBuilder.php
@@ -92,7 +92,7 @@ class SqLiteQueryBuilder {
 	 * @return QueryBuilderInterface
 	 */
 	public function exactMatch($propertyName, $propertyValue) {
-		$this->where[] = "(" . $propertyName . " = '" . $propertyValue . "')";
+		$this->where[] = sprintf("(`%s`) = '%s'", $propertyName, $propertyValue);
 
 		return $this;
 	}
@@ -105,7 +105,7 @@ class SqLiteQueryBuilder {
 	 * @return QueryBuilderInterface
 	 */
 	public function like($propertyName, $propertyValue) {
-		$this->where[] = "(" . $propertyName . " LIKE '%" . $propertyValue . "%')";
+		$this->where[] = "(`" . $propertyName . "` LIKE '%" . $propertyValue . "%')";
 
 		return $this;
 	}


### PR DESCRIPTION
Although the sqlLite documentation about quoting states that back-ticks are not SQL standard, a like query only works with the back-ticks. All other quoting lead to a not matching statement.