### PR TITLE
BUGFIX: use correct quotes for character escape sequences

### DIFF
--- a/Classes/Domain/Service/MysqlIndex.php
+++ b/Classes/Domain/Service/MysqlIndex.php
@@ -145,8 +145,8 @@ class MysqlIndex implements IndexInterface
             $valueNamesString .= $this->preparedStatementArgumentName($statementArgumentNumber) . ', ';
             $statementArgumentNumber++;
         }
-        $propertyColumnNamesString = trim($propertyColumnNamesString, ', \t\n\r\0\x0B');
-        $valueNamesString = trim($valueNamesString, ', \t\n\r\0\x0B');
+        $propertyColumnNamesString = trim($propertyColumnNamesString, ", \t\n\r\0\x0B");
+        $valueNamesString = trim($valueNamesString, ", \t\n\r\0\x0B");
         $preparedStatement = $this->connection->prepare('REPLACE INTO "fulltext_objects" (' . $propertyColumnNamesString . ') VALUES (' . $valueNamesString . ')');
 
         $preparedStatement->bindValue(':__identifier__', $identifier);


### PR DESCRIPTION
Character escape sequences should be enclosed in double quotes. Otherwise the literal characters t, n, r, 0, x, B will be stripped from the input.
The SqLiteIndex already implements this behavior correctly.

I encountered the problem with an argument list ending in 0, where `:arg40` was trimmed to `:arg4` which of course had the wrong value.
The same might happen for column names when unlucky.